### PR TITLE
Fix missing semicolon in inactivity query

### DIFF
--- a/Assessment_Q3.sql
+++ b/Assessment_Q3.sql
@@ -73,6 +73,7 @@ SELECT -- 1,976
 FROM account_inactivity_metric 
 WHERE no_of_txn = 0 AND (inactivity_days > 365 OR inactivity_days IS NULL)
 ORDER BY inactivity_days IS NULL, inactivity_days
+;
 
 
 /*


### PR DESCRIPTION
## Summary
- fix missing semicolon at end of final SELECT in assessment query 3

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852707e63f0832097ea7f184516dc8b